### PR TITLE
Update backing library to use vectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/__pycache__/**
+launch.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "physics-simulations"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/physics-simulations/physics_simulations/basic_gravity.py
+++ b/physics-simulations/physics_simulations/basic_gravity.py
@@ -1,15 +1,16 @@
 import vpython
 import physical_laws as pl
+import vector_math as vm
 
-sphere1 = vpython.sphere(pos=vpython.vector(-25, 0, 0), radius=20.5, color=vpython.color.red)
-sphere2 = vpython.sphere(pos=vpython.vector(25, 0, 0), radius=16.75, color=vpython.color.blue)
+sphere1 = vpython.sphere(pos=vpython.vector(-5, -9, -14), radius=20.5, color=vpython.color.red)
+sphere2 = vpython.sphere(pos=vpython.vector(9, 17, 14), radius=3.75, color=vpython.color.blue)
 sphere1.mass = 80e15
 sphere1.force = 0
-sphere2.mass = 60e15
+sphere2.mass = 60e11
 sphere2.force = 0
 
 f_curves = vpython.graph(title="Force vs. Time", xtitle="Time (s)", ytitle="Force (N)")
-velocity_curves = vpython.graph(title="Velocity vs. Time", xtitle="Time (s)", ytitle="Velocity (m/s)")
+velocity_curves = vpython.graph(title="Abs Velocity vs. Time", xtitle="Time (s)", ytitle="Velocity (m/s)")
 sphere1_fcurve = vpython.gcurve(graph=f_curves, color=vpython.color.red)
 sphere2_fcurve = vpython.gcurve(graph=f_curves, color=vpython.color.blue)
 sphere1_velocity_curve = vpython.gcurve(graph=velocity_curves, color=vpython.color.red, dot=True)
@@ -20,25 +21,25 @@ def main_loop(max_t: float = 5, dt: float = 0.001, compute_rate: float = 100) ->
     t = 0
     while t < max_t:
         vpython.rate(compute_rate)
-        distance = abs(sphere2.pos.x - sphere1.pos.x)
-        if distance >= (sphere1.radius + sphere2.radius):
+        distance = sphere2.pos - sphere1.pos
+        if distance.mag >= (sphere1.radius + sphere2.radius):
             # update
-            sphere1.force = pl.newton_universal_gravitation(sphere1.mass, sphere2.mass, distance)
-            sphere2.force = -sphere1.force
+            sphere2.force = pl.newton_universal_gravitation(sphere1.mass, sphere2.mass, vm.Vec_3D(*distance.value))
+            sphere1.force = -sphere2.force
             
-            sphere1_new_pos = pl.kinematic_distance(dt, sphere1.pos.x, 0, sphere1.force / sphere1.mass)
-            sphere2_new_pos = pl.kinematic_distance(dt, sphere2.pos.x, 0, sphere2.force / sphere2.mass)
-            sphere1.pos.x, sphere2.pos.x = sphere1_new_pos, sphere2_new_pos
+            sphere1_new_pos = pl.kinematic_distance(dt, distance=vm.Vec_3D(*sphere1.pos.value), acceleration=sphere1.force / sphere1.mass)
+            sphere2_new_pos = pl.kinematic_distance(dt, distance=vm.Vec_3D(*sphere2.pos.value), acceleration=sphere2.force / sphere2.mass)
+            sphere1.pos, sphere2.pos = vpython.vector(*sphere1_new_pos), vpython.vector(*sphere2_new_pos)
         else: 
-            sphere1.force = 0
-            sphere2.force = 0
+            sphere1.force = vm.Vec_3D.ZERO
+            sphere2.force = vm.Vec_3D.ZERO
             
         
         t += dt
-        sphere1_fcurve.plot(t, sphere1.force)
-        sphere2_fcurve.plot(t, sphere2.force)
-        sphere1_velocity_curve.plot(t, t * sphere1.force / sphere1.mass)
-        sphere2_velocity_curve.plot(t, t * sphere2.force / sphere2.mass)
+        sphere1_fcurve.plot(t, sphere1.force.magnitude)
+        sphere2_fcurve.plot(t, -sphere2.force.magnitude)
+        sphere1_velocity_curve.plot(t, (t * sphere1.force / sphere1.mass).magnitude)
+        sphere2_velocity_curve.plot(t, (t * sphere2.force / sphere2.mass).magnitude)
             
             
 main_loop(10, compute_rate=400)

--- a/physics-simulations/physics_simulations/physical_laws.py
+++ b/physics-simulations/physics_simulations/physical_laws.py
@@ -1,14 +1,18 @@
 import logging
 
-NEWTON_G_CONST = 6.67430e-11
-
+from vector_math import Vec_3D
 
 logger = logging.getLogger(__name__)
 
 
+NEWTON_G_CONST = 6.67430e-11
+
 def kinematic_distance(
-    time: float, distance: float = 0, velocity: float = 0, acceleration: float = 0
-) -> float:
+    time: float,
+    distance: Vec_3D = Vec_3D.ZERO,
+    velocity: Vec_3D = Vec_3D.ZERO,
+    acceleration: Vec_3D = Vec_3D.ZERO,
+) -> Vec_3D:
     """
     Calculates the distance travelled using the kinematic equation:
     distance = initial_distance + initial_velocity * time + 0.5 * acceleration * time ** 2
@@ -17,9 +21,7 @@ def kinematic_distance(
     """
     try:
         if time < 0:
-            raise ValueError(
-                f"Time must be positive. Time: {time}"
-            )
+            raise ValueError(f"Time must be positive. Time: {time}")
         return distance + velocity * time + 0.5 * acceleration * time**2
     except ValueError as e:
         logger.error(e)
@@ -27,19 +29,16 @@ def kinematic_distance(
 
 
 def newton_universal_gravitation(
-    mass1: float, mass2: float, distance: float, G: float = NEWTON_G_CONST
-) -> float:
+    mass1: float, mass2: float, distance: Vec_3D, G: float = NEWTON_G_CONST
+) -> Vec_3D:
     """
     Calculates the force of attraction between two masses in Newtons.
-    Masses are assumed to be in kilograms and distance in meters.
-    Distance can be treated as a vector, but the magnitude is used.
+    Masses are assumed to be in kilograms and distances expressed in meters.
     """
     try:
-        if any([mass1 <= 0, mass2 <= 0]):
-            raise ValueError(
-                f"Masses must be positive. Masses: {mass1}, {mass2}"
-            )
-        return G * (mass1 * mass2) / (abs(distance) ** 2)
+        if any([mass1 <= 0, mass2 <= 0, distance.magnitude <= 0]):
+            raise ValueError(f"Masses and distance magnitude must be positive. Masses: {mass1}, {mass2}, Distance: {distance}")
+        return -1 * distance.unit_vector * G * (mass1 * mass2) / (distance.magnitude**2)
     except ValueError as e:
         logger.error(e)
         raise

--- a/physics-simulations/physics_simulations/vector_math.py
+++ b/physics-simulations/physics_simulations/vector_math.py
@@ -1,0 +1,112 @@
+import logging
+
+import numpy as np
+
+
+logger = logging.getLogger(__name__)
+
+class Vec_3D:
+    """
+    A 3D vector class building on top of numpy's array class.
+    """
+    
+    _data: np.array
+    ZERO: "Vec_3D" 
+    RIGHT: "Vec_3D"
+    LEFT: "Vec_3D"
+    UP: "Vec_3D"
+    DOWN: "Vec_3D"
+    FORWARD: "Vec_3D"
+    BACKWARD: "Vec_3D"
+    
+    
+    def __init__(self, x: float = 0, y: float = 0, z: float = 0) -> None:
+        self._data = np.array([x, y, z])
+        
+    @property
+    def x(self) -> float:
+        return self._data[0]
+    
+    @x.setter
+    def x(self, value: float) -> None:
+        self._data[0] = value
+    
+    @property
+    def y(self) -> float:
+        return self._data[1]
+    
+    @y.setter
+    def y(self, value: float) -> None:
+        self._data[1] = value
+    
+    @property
+    def z(self) -> float:
+        return self._data[2]
+    
+    @z.setter
+    def z(self, value: float) -> None:
+        self._data[2] = value
+    
+    @property 
+    def magnitude(self) -> float:
+        return np.linalg.norm(self._data)
+    
+    @property
+    def unit_vector(self) -> "Vec_3D":
+        return Vec_3D(*(self._data / self.magnitude))
+    
+    def __str__(self) -> str:
+        return f"Vec_3D({self.x}, {self.y}, {self.z})"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+    
+    def __eq__(self, other) -> bool:
+        if isinstance(other, Vec_3D):
+            return np.allclose(self._data, other._data, rtol=1e-12, atol=1e-11)
+        else:
+            raise TypeError(f"Cannot compare {type(self)} and {type(other)}")
+        
+    def __add__(self, other) -> "Vec_3D":
+        if isinstance(other, Vec_3D):
+            return Vec_3D(*(self._data + other._data))
+        else:
+            raise TypeError(f"Cannot add {type(self)} and {type(other)}")
+        
+    def __sub__(self, other) -> "Vec_3D":
+        if isinstance(other, Vec_3D):
+            return Vec_3D(*(self._data - other._data))
+        else:
+            raise TypeError(f"Cannot subtract {type(self)} and {type(other)}")
+    
+    def __neg__(self) -> "Vec_3D":
+        return Vec_3D(*(-self._data))
+        
+    def __mul__(self, other) -> "Vec_3D":
+        if isinstance(other, (int, float)):
+            return Vec_3D(*(self._data * other))
+        else:
+            raise TypeError(f"Cannot multiply {type(self)} and {type(other)}")
+        
+    def __rmul__(self, other) -> "Vec_3D":
+        return self.__mul__(other)
+
+    def __truediv__(self, other) -> "Vec_3D":
+        if isinstance(other, (int, float)):
+            return Vec_3D(*(self._data / other))
+        else:
+            raise TypeError(f"Cannot divide {type(self)} and {type(other)}")
+
+    def __iter__(self):
+        return iter(self._data)
+    
+    
+
+# I don't know how to turn these into static class variables
+Vec_3D.ZERO = Vec_3D(0, 0, 0)
+Vec_3D.RIGHT = Vec_3D(1, 0, 0)
+Vec_3D.LEFT = Vec_3D(-1, 0, 0)
+Vec_3D.UP = Vec_3D(0, 1, 0)
+Vec_3D.DOWN = Vec_3D(0, -1, 0)
+Vec_3D.FORWARD = Vec_3D(0, 0, 1)
+Vec_3D.BACKWARD = Vec_3D(0, 0, -1)

--- a/physics-simulations/tests/test_physical_laws.py
+++ b/physics-simulations/tests/test_physical_laws.py
@@ -1,21 +1,41 @@
+import math
+
 import pytest
-import physics_simulations.physical_laws as pl
+
+from physics_simulations import physical_laws as pl
+from physics_simulations import vector_math as vm
 
 
 class TestPhysicalLaws:
     def test_kinematic_distance(self):
-        assert pl.kinematic_distance(0) == 0
-        assert pl.kinematic_distance(1, 0, 0, 0) == 0
-        assert pl.kinematic_distance(1, 1, 0, 0) == 1
-        assert pl.kinematic_distance(1, 0, 1, 0) == 1
-        assert pl.kinematic_distance(1, 0, 0, 1) == 0.5
-        assert pl.kinematic_distance(1, 10, 20, 30) == 45
+        assert pl.kinematic_distance(0) == vm.Vec_3D.ZERO
+        assert (
+            pl.kinematic_distance(10, vm.Vec_3D.ZERO, vm.Vec_3D.ZERO, vm.Vec_3D.ZERO)
+            == vm.Vec_3D.ZERO
+        )
+        assert pl.kinematic_distance(
+            2,
+            vm.Vec_3D.ZERO,
+            vm.Vec_3D.RIGHT + vm.Vec_3D.UP,
+            vm.Vec_3D.ZERO,
+        ) == vm.Vec_3D(2, 2, 0)
+        assert pl.kinematic_distance(
+            1,
+            vm.Vec_3D.RIGHT * 10,
+            vm.Vec_3D.DOWN * 20,
+            vm.Vec_3D.UP * 30,
+        ) == vm.Vec_3D(10, -5, 0)
         with pytest.raises(ValueError):
             pl.kinematic_distance(-1, 0, 0, 0)
 
     def test_newton_gravitation(self):
-        assert pl.newton_universal_gravitation(1, 1, 1) == pl.NEWTON_G_CONST
-        assert pl.newton_universal_gravitation(20, 10, 2) == pl.NEWTON_G_CONST * 50
-        assert pl.newton_universal_gravitation(20, 10, -2) == -pl.NEWTON_G_CONST * 50
+        assert (
+            pl.newton_universal_gravitation(1, 1, vm.Vec_3D.RIGHT)
+            == -pl.NEWTON_G_CONST * vm.Vec_3D.RIGHT
+        )
+        assert pl.newton_universal_gravitation(
+            20, 10, vm.Vec_3D(1, 1, 0)
+        ) == -pl.NEWTON_G_CONST * 100 * vm.Vec_3D(1 / math.sqrt(2), 1 / math.sqrt(2), 0)
+        assert pl.newton_universal_gravitation(20, 10, vm.Vec_3D.LEFT) == pl.NEWTON_G_CONST * 200 * vm.Vec_3D.RIGHT
         with pytest.raises(ValueError):
-            pl.newton_universal_gravitation(0, 1, 1)
+            pl.newton_universal_gravitation(0, 1, vm.Vec_3D.RIGHT)

--- a/physics-simulations/tests/test_vector_math.py
+++ b/physics-simulations/tests/test_vector_math.py
@@ -1,0 +1,43 @@
+import pytest
+
+from physics_simulations import vector_math as vm
+
+class TestVectorMath:
+        
+    
+    def test_vector_direction(self):
+        assert vm.Vec_3D.UP == vm.Vec_3D(0, 1, 0)
+        assert vm.Vec_3D.DOWN == vm.Vec_3D(0, -1, 0)
+        assert vm.Vec_3D.LEFT == vm.Vec_3D(-1, 0, 0)
+        assert vm.Vec_3D.RIGHT == vm.Vec_3D(1, 0, 0)
+        assert vm.Vec_3D.FORWARD == vm.Vec_3D(0, 0, 1)
+        assert vm.Vec_3D.BACKWARD == vm.Vec_3D(0, 0, -1)
+        assert vm.Vec_3D.ZERO == vm.Vec_3D(0, 0, 0)
+        
+    def test_vector_properties(self):
+        vec = vm.Vec_3D(2, 3, 6)
+        assert vec.magnitude == 7
+        assert vec.unit_vector == vm.Vec_3D(2/7, 3/7, 6/7)
+
+
+    def test_vector_ops(self):
+        assert vm.Vec_3D.RIGHT + vm.Vec_3D.LEFT == vm.Vec_3D.ZERO
+        assert vm.Vec_3D.RIGHT - vm.Vec_3D.RIGHT == vm.Vec_3D.ZERO
+        assert -vm.Vec_3D.UP == vm.Vec_3D.DOWN
+        assert vm.Vec_3D.RIGHT * 2 == vm.Vec_3D(2, 0, 0)
+        assert 2 * vm.Vec_3D.RIGHT == vm.Vec_3D(2, 0, 0)
+        assert vm.Vec_3D.RIGHT / 2 == vm.Vec_3D(0.5, 0, 0)
+        assert [*vm.Vec_3D.RIGHT._data] == [1, 0, 0]
+        
+    def test_vector_illegal_ops(self):
+        with pytest.raises(TypeError):
+            vm.Vec_3D.RIGHT + 1
+        with pytest.raises(TypeError):
+            vm.Vec_3D.RIGHT - 1
+        with pytest.raises(TypeError):
+            vm.Vec_3D.RIGHT * vm.Vec_3D.RIGHT
+        with pytest.raises(TypeError):
+            vm.Vec_3D.RIGHT / vm.Vec_3D.RIGHT
+        with pytest.raises(TypeError):
+            3 / vm.Vec_3D.RIGHT
+


### PR DESCRIPTION
The `vpython` library is proving to be useful for creating short-term visual simulations, but the library doesn't play nice with modern standards or other future ideas (e.g., `numpy` is a good package for mathematical operations).

This motivated me to create an interfacing class for making 3D Vector calculations.  

In the basic_gravity example, the "planet" masses are updated to have 3D positioning:
![8dc1b7dbb06a5fe79e8e11c691159cde](https://github.com/TresTres/simulations-workbook/assets/14167519/668c1961-0822-4625-8e35-cf7baaa2315d)
![a5da88bc221f0d227c1a58b73b146c7a](https://github.com/TresTres/simulations-workbook/assets/14167519/511bd24f-4056-4577-906a-267f1839376e)
